### PR TITLE
Point deserialize from string coordinates

### DIFF
--- a/marshmallow_mongoengine/fields.py
+++ b/marshmallow_mongoengine/fields.py
@@ -28,7 +28,7 @@ class Point(fields.Field):
         try:
             return dict(
                 type='Point',
-                coordinates=[value['x'], value['y']]
+                coordinates=[float(value['x']), float(value['y'])]
             )
         except:
             raise ValidationError('invalid Point `%s`' % value)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -289,4 +289,13 @@ class TestFields(BaseTest):
         dump = DocSchema().dump(doc)
         assert not dump.errors
         assert dump.data['point'] == { 'x': 10, 'y': 20 }
+        load = DocSchema().load(dump.data)
+        assert not load.errors
+        assert load.data.point == { 'type': 'Point', 'coordinates': [10, 20] }
+        # Deserialize Point with coordinates passed as string
+        data = {'point': { 'x': '10', 'y': '20' }}
+        load = DocSchema().load(data)
+        assert not load.errors
+        assert load.data.point == { 'type': 'Point', 'coordinates': [10, 20] }
+
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -297,5 +297,7 @@ class TestFields(BaseTest):
         load = DocSchema().load(data)
         assert not load.errors
         assert load.data.point == { 'type': 'Point', 'coordinates': [10, 20] }
-
-
+        # Try to load invalid coordinates
+        data = {'point': { 'x': '10', 'y': '20foo' }}
+        load = DocSchema().load(data)
+        assert 'point' in load.errors


### PR DESCRIPTION
This change allows `Point` to deserialize coordinates provided as strings rather than numbers (floats or ints).

I'm serving an API using webargs/flask and I'm using a [NestedQueryFlaskParser](https://webargs.readthedocs.io/en/latest/advanced.html#custom-parsers) as suggested in the docs.

I receive a query like this one:

    http PUT "http://localhost:5000/buildings/57512e2227b613712d824fe9?name=building&position.x=100&position.y=50"

The custom parser generates a dictionary but does not deserialize the coordinate values into numbers.

I guess marshmallow-mongoengine's `Point` is the right place to do that. Or am I wrong?

@touilleMan, @kevin0571 any advice?